### PR TITLE
fix where spaced() didn't work for horizontally distributed layers

### DIFF
--- a/distributeLayers.coffee
+++ b/distributeLayers.coffee
@@ -80,9 +80,11 @@ module.exports.distributeLayers =
 		for index, layer of options.layers
 			if options.direction == "vertical"
 				layer.y = offset
+				offset += layer.height + spacing
 			else
 				layer.x = offset
-			offset += layer.height + spacing
+				offset += layer.width + spacing
+			
 
 		# Remember which method was used
 		this._setLayerMetadata(layer, 'methodUsed', 'spaced')


### PR DESCRIPTION
This fixes an issue where the spaced method didn't take width into account for horizontally distributed layers. 

How to reproduce the bug:

```
{ distributeLayers } = require "distributeLayers"

layers = []
layers[0] = new Layer
	width: 50
layers[1] = new Layer
	width: 50
layers[2] = new Layer
	width: 50

distributeLayers.spaced
	layers: layers
	direction: "horizontal"
	max: Screen.width
```