### PR TITLE
only add margin/spacing if the layer width/height is greater than 0 t…

### DIFF
--- a/distributeLayers.coffee
+++ b/distributeLayers.coffee
@@ -44,10 +44,10 @@ module.exports.distributeLayers =
 		for index, layer of options.layers
 			if options.direction == "vertical"
 				layer.y = offset
-				offset += layer.height + options.margin
+				offset += layer.height + options.margin if layer.height > 0
 			else
 				layer.x = offset
-				offset += layer.width + options.margin
+				offset += layer.width + options.margin if layer.width > 0
 
 		# Remember which method was used
 		this._setLayerMetadata(layer, 'methodUsed', 'sameMargin')
@@ -80,11 +80,11 @@ module.exports.distributeLayers =
 		for index, layer of options.layers
 			if options.direction == "vertical"
 				layer.y = offset
-				offset += layer.height + spacing
+				offset += layer.height + spacing if layer.height > 0
 			else
 				layer.x = offset
-				offset += layer.width + spacing
-			
+				offset += layer.width + spacing if layer.width > 0
+
 
 		# Remember which method was used
 		this._setLayerMetadata(layer, 'methodUsed', 'spaced')


### PR DESCRIPTION
…o facilitate programmatically adding (initially) hidden layers in the distribution

we had a problem where we were wanting to by programmatically distribute all layers in a set, some of them initially hidden (height 0, so we can reveal them via animation), but the margins were still adding to the total, causing unwanted spacing in our (specifically) ScrollComponent content.

This fix will prevent this issue from occurring, and I believe is the right way to handle this situation. 